### PR TITLE
Updated API endpoint

### DIFF
--- a/FHEM/59_LuftdatenInfo.pm
+++ b/FHEM/59_LuftdatenInfo.pm
@@ -283,7 +283,7 @@ sub LuftdatenInfo_GetHttpResponse($$) {
     header   => "Accept: application/json",
     callback => \&LuftdatenInfo_ParseHttpResponse,
   };
-  $param->{url} = "http://api.luftdaten.info/v1/sensor/$arg/"
+  $param->{url} = "http://data.sensor.community/airrohr/v1/sensor/$arg/"
     if($MODE eq "remote");
   $param->{url} = "http://$arg/data.json"
     if($MODE eq "local");


### PR DESCRIPTION
As the old API endpoint 'http://api.luftdaten.info/v1/sensor/$arg/' does not work anymore it needs to be changed to 'http://data.sensor.community/airrohr/v1/sensor/$arg/' according to the documentation https://github.com/opendata-stuttgart/meta/wiki/APIs